### PR TITLE
Adds `stats()` for `Hyperf\Engine\Coroutinue`

### DIFF
--- a/src/Contract/CoroutineInterface.php
+++ b/src/Contract/CoroutineInterface.php
@@ -67,4 +67,6 @@ interface CoroutineInterface
      * Execute callback when coroutine destruct.
      */
     public static function defer(callable $callable);
+
+    public static function stats(): array;
 }

--- a/src/Coroutine.php
+++ b/src/Coroutine.php
@@ -97,4 +97,9 @@ class Coroutine implements CoroutineInterface
     {
         SwooleCo::defer($callable);
     }
+
+    public static function stats(): array
+    {
+        return SwooleCo::stats();
+    }
 }


### PR DESCRIPTION
Swow:

```php
// Hyperf\Engine\Coroutine
// ...
public function stats():array
{
    return [
        'coroutinue_num' => SwowCo::count(),
    ];
}
```