### PR TITLE
fixed bug that the exception occurs when there is no Swoole

### DIFF
--- a/src/Coroutine.php
+++ b/src/Coroutine.php
@@ -58,6 +58,9 @@ class Coroutine implements CoroutineInterface
 
     public static function id()
     {
+        if (! class_exists(SwooleCo::class)) {
+            return 0;
+        }
         return SwooleCo::getCid();
     }
 


### PR DESCRIPTION
如果不判断Swoole exists 会报错, DI 依赖了Context, 导致DI 强依赖了Swoole