### PR TITLE
Fix the bug that `go` function is not found

### DIFF
--- a/src/SafeSocket.php
+++ b/src/SafeSocket.php
@@ -101,7 +101,7 @@ class SafeSocket implements SocketInterface
 
         $this->loop = true;
 
-        go(function () {
+        Coroutine::create(function () {
             while (true) {
                 $data = $this->channel->pop(-1);
                 if ($this->channel->isClosing()) {


### PR DESCRIPTION
Error: Call to undefined function Hyperf\Engine\go() in  SafeSocket.php:104