### PR TITLE
EventStream 报错问题 Fix `Swoole\Http\Response@end` 新版本可能会返回为null

### DIFF
--- a/src/Http/WritableConnection.php
+++ b/src/Http/WritableConnection.php
@@ -34,7 +34,7 @@ class WritableConnection implements Writable
         return $this->response;
     }
 
-    public function end(): bool
+    public function end(): ?bool
     {
         return $this->response->end();
     }


### PR DESCRIPTION
[issues](https://github.com/hyperf/hyperf/issues/7154)

Swoole 5.1.4 版本 Swoole\Http\Response@end 方法可能会返回null 导致 `prod.ERROR: Hyperf\Engine\Http\WritableConnection::end(): Return value must be of type bool, null returned[39]` 错误, 目前遇到影响了 EventStream 类

```php
<?php

declare(strict_types=1);
/**
 * This file is part of Hyperf.
 *
 * @link     https://www.hyperf.io
 * @document https://hyperf.wiki
 * @contact  group@hyperf.io
 * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
 */

namespace Hyperf\Engine\Http;

use Hyperf\Engine\Contract\Http\Writable;
use Swoole\Http\Response;

class WritableConnection implements Writable
{
    public function __construct(protected Response $response)
    {
    }

    public function write(string $data): bool
    {
        return $this->response->write($data);
    }

    /**
     * @return Response
     */
    public function getSocket(): mixed
    {
        return $this->response;
    }

    public function end(): bool
    {
        return $this->response->end(); // Swoole 5.1.4 版本 可能返回为 null 
    }
}
```
swoole/ide-helper 提示的Swoole\Http\Response@end 返回为bool
不知是否和本次 [Swoole](https://github.com/swoole/swoole-src/commit/cf8c93d28b162defd5a2f3c4eced6530ed90bc71#diff-476eee9b3976d0be177c171e8e8957ae8aa50313eb6168ffe157f6536acfeee2R476) 改动有关