### PR TITLE
Compatible with swoole version 6.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os: [ ubuntu-latest ]
         php-version: [ '8.1', '8.2', '8.3' ]
-        swoole-version: [ 'v5.0.3', 'v5.1.2', 'master' ]
+        swoole-version: [ 'v5.0.3', 'v5.1.6', 'v6.0.0', 'master' ]
         exclude:
           - php-version: '8.3'
             swoole-version: 'v5.0.3'

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -52,7 +52,11 @@ class Client extends HttpClient implements ClientInterface
         $result = [];
         foreach ($headers as $name => $header) {
             // The key of header is lower case.
-            $result[$name][] = $header;
+            if (is_array($header)) {
+                $result[$name] = $header;
+            } else {
+                $result[$name][] = $header;
+            }
         }
         if ($this->set_cookie_headers) {
             $result['set-cookie'] = $this->set_cookie_headers;

--- a/src/Signal.php
+++ b/src/Signal.php
@@ -19,6 +19,6 @@ class Signal implements SignalInterface
 {
     public static function wait(int $signo, float $timeout = -1): bool
     {
-        return System::waitSignal($signo, $timeout);
+        return System::waitSignal($signo, $timeout) !== false;
     }
 }


### PR DESCRIPTION
Compatible the return value of the System::waitSignal() in swoole version 6.0


see https://github.com/swoole/swoole-src/commit/367da9daa4f327ffaddc44c6d914c1e254585686