### PR TITLE
Ensure `getPayloadData` allows null

### DIFF
--- a/src/WebSocket/Frame.php
+++ b/src/WebSocket/Frame.php
@@ -171,7 +171,7 @@ class Frame implements FrameInterface
         return (clone $this)->setMaskingKey($maskingKey);
     }
 
-    public function getPayloadData(): StreamInterface
+    public function getPayloadData(): ?StreamInterface
     {
         return $this->payloadData;
     }

--- a/src/WebSocket/Frame.php
+++ b/src/WebSocket/Frame.php
@@ -32,7 +32,7 @@ class Frame implements FrameInterface
      */
     public const PONG = '278a0027';
 
-    protected ?StreamInterface $payloadData = null;
+    protected StreamInterface $payloadData;
 
     public function __construct(
         protected bool $fin = true,
@@ -44,9 +44,7 @@ class Frame implements FrameInterface
         protected string $maskingKey = '',
         mixed $payloadData = '',
     ) {
-        if ($payloadData !== null && $payloadData !== '') {
-            $this->setPayloadData($payloadData);
-        }
+        $this->setPayloadData($payloadData);
     }
 
     public function __toString()
@@ -136,7 +134,7 @@ class Frame implements FrameInterface
 
     public function getPayloadLength(): int
     {
-        return $this->payloadData?->getSize() ?? 0;
+        return $this->payloadData->getSize() ?? 0;
     }
 
     public function setPayloadLength(int $payloadLength): static
@@ -171,7 +169,7 @@ class Frame implements FrameInterface
         return (clone $this)->setMaskingKey($maskingKey);
     }
 
-    public function getPayloadData(): ?StreamInterface
+    public function getPayloadData(): StreamInterface
     {
         return $this->payloadData;
     }


### PR DESCRIPTION
This PR fixes the occasional error when `payloadData` is null but `getPayloadData` only allows returning a non null value.

```
TypeError: Hyperf\Engine\WebSocket\Frame::getPayloadData(): Return value must be of type Psr\Http\Message\StreamInterface null returned
```